### PR TITLE
recycle timer

### DIFF
--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -22,13 +22,14 @@ func BenchmarkContinue(b *testing.B) {
 }
 
 func BenchmarkDo(b *testing.B) {
+	err := errors.New("error")
 	policy := &Policy{
 		MaxCount: 5,
 	}
 	for i := 0; i < b.N; i++ {
 		policy.Do(context.Background(), func() error {
 			dummyFunc()
-			return errors.New("error")
+			return err
 		})
 	}
 }

--- a/retry.go
+++ b/retry.go
@@ -148,6 +148,9 @@ func (r *Retrier) sleepContext(ctx context.Context, d time.Duration) error {
 		return testSleep(ctx, d)
 	}
 
+	if d == 0 {
+		return ctx.Err()
+	}
 	if deadline, ok := ctx.Deadline(); ok {
 		if deadline.Sub(time.Now()) < d {
 			// skip sleeping.

--- a/retry.go
+++ b/retry.go
@@ -35,6 +35,7 @@ type Retrier struct {
 	policy *Policy
 	count  int
 	delay  time.Duration
+	timer  *time.Timer
 }
 
 // Start starts retrying
@@ -126,7 +127,7 @@ func (r *Retrier) Continue() bool {
 		return false
 	}
 
-	if err := sleepContext(r.ctx, r.delay+r.policy.randomJitter()); err != nil {
+	if err := r.sleepContext(r.ctx, r.delay+r.policy.randomJitter()); err != nil {
 		return false
 	}
 
@@ -142,7 +143,7 @@ func (r *Retrier) Continue() bool {
 var testSleep func(ctx context.Context, d time.Duration) error
 
 // Context supported time.Sleep
-func sleepContext(ctx context.Context, d time.Duration) error {
+func (r *Retrier) sleepContext(ctx context.Context, d time.Duration) error {
 	if testSleep != nil {
 		return testSleep(ctx, d)
 	}
@@ -155,12 +156,19 @@ func sleepContext(ctx context.Context, d time.Duration) error {
 		}
 	}
 
-	t := time.NewTimer(d)
+	t := r.timer
+	if t == nil {
+		t = time.NewTimer(d)
+		r.timer = t
+	} else {
+		t.Reset(d)
+	}
 	defer t.Stop()
 	select {
 	case <-t.C:
 		return nil
 	case <-ctx.Done():
+		r.timer = nil
 		return ctx.Err()
 	}
 }

--- a/retry_test.go
+++ b/retry_test.go
@@ -100,9 +100,11 @@ func TestRetry_WithMaxCount(t *testing.T) {
 }
 
 func TestSleepContext(t *testing.T) {
+	policy := &Policy{}
+	retrier := policy.Start(context.Background())
 	t.Run("normal", func(t *testing.T) {
 		start := time.Now()
-		err := sleepContext(context.Background(), time.Second)
+		err := retrier.sleepContext(context.Background(), time.Second)
 		if err != nil {
 			t.Error(err)
 		}
@@ -122,7 +124,7 @@ func TestSleepContext(t *testing.T) {
 		}()
 
 		start := time.Now()
-		err := sleepContext(ctx, time.Second)
+		err := retrier.sleepContext(ctx, time.Second)
 		if err != context.Canceled {
 			t.Error(err)
 		}
@@ -137,7 +139,7 @@ func TestSleepContext(t *testing.T) {
 		defer cancel()
 
 		start := time.Now()
-		err := sleepContext(ctx, time.Second)
+		err := retrier.sleepContext(ctx, time.Second)
 		if err != context.DeadlineExceeded {
 			t.Error(err)
 		}


### PR DESCRIPTION
before:

```
BenchmarkContinue-4   	   70143	     14485 ns/op	     832 B/op	      12 allocs/op
BenchmarkDo-4   	   62914	     17216 ns/op	     992 B/op	      22 allocs/op
```

after:

```
BenchmarkContinue-4   	   78696	     14644 ns/op	     208 B/op	       3 allocs/op
BenchmarkDo-4   	   63008	     17721 ns/op	     368 B/op	      13 allocs/op
```