### PR TITLE
use global rand functions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,7 +10,8 @@ jobs:
     strategy:
       matrix:
         go:
-          - "1"
+          - "stable"
+          - "1.22.0-rc.1"
           - "1.21"
           - "1.20"
           - "1.19"

--- a/rand.go
+++ b/rand.go
@@ -1,0 +1,21 @@
+//go:build !go1.22
+// +build !go1.22
+
+package retry
+
+import (
+	"math/rand"
+	"time"
+)
+
+func (p *Policy) randomJitter() time.Duration {
+	jitter := int64(p.Jitter)
+	if jitter == 0 {
+		return 0
+	}
+
+	if jitter < 0 {
+		return -time.Duration(rand.Int63n(-jitter))
+	}
+	return time.Duration(rand.Int63n(jitter))
+}

--- a/rand_v2.go
+++ b/rand_v2.go
@@ -1,0 +1,21 @@
+//go:build go1.22
+// +build go1.22
+
+package retry
+
+import (
+	"math/rand/v2"
+	"time"
+)
+
+func (p *Policy) randomJitter() time.Duration {
+	jitter := p.Jitter
+	if jitter == 0 {
+		return 0
+	}
+
+	if jitter < 0 {
+		return -rand.N(-jitter)
+	}
+	return rand.N(jitter)
+}


### PR DESCRIPTION
From Go 1.20, `math/rand` uses thread-local source if possible.
It is faster than using the global source because it avoid locking cost.

go version: go version go1.22rc1 darwin/arm64

```
goos: darwin
goarch: arm64
pkg: github.com/shogo82148/go-retry
                   │   .old.txt    │              .new.txt               │
                   │    sec/op     │   sec/op     vs base                │
Continue-10            535.0n ± 0%   564.7n ± 0%   +5.55% (p=0.000 n=10)
ContinueSuccess-10     3.724n ± 0%   3.725n ± 0%        ~ (p=0.723 n=10)
Do-10                  2.864µ ± 0%   2.985µ ± 0%   +4.24% (p=0.000 n=10)
DoSuccess-10           5.555n ± 1%   5.532n ± 1%        ~ (p=0.101 n=10)
Do_Parallel-10       14192.0n ± 0%   434.2n ± 1%  -96.94% (p=0.000 n=10)
geomean                214.1n        108.6n       -49.29%

                   │   .old.txt   │              .new.txt               │
                   │     B/op     │    B/op     vs base                 │
Continue-10          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ContinueSuccess-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Do-10                16.00 ± 0%     16.00 ± 0%       ~ (p=1.000 n=10) ¹
DoSuccess-10         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Do_Parallel-10       16.00 ± 0%     16.00 ± 0%       ~ (p=1.000 n=10) ¹
geomean                         ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean

                   │   .old.txt   │              .new.txt               │
                   │  allocs/op   │ allocs/op   vs base                 │
Continue-10          0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
ContinueSuccess-10   0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Do-10                1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
DoSuccess-10         0.000 ± 0%     0.000 ± 0%       ~ (p=1.000 n=10) ¹
Do_Parallel-10       1.000 ± 0%     1.000 ± 0%       ~ (p=1.000 n=10) ¹
geomean                         ²               +0.00%                ²
¹ all samples are equal
² summaries must be >0 to compute geomean
```