### PR TITLE
[fix] Correct MarkPermanent/MarkTemporary documentation

### DIFF
--- a/func.go
+++ b/func.go
@@ -5,10 +5,14 @@ import (
 	"errors"
 )
 
-// DoValue executes f with retrying policy.
+// DoValue executes f with retrying policy and returns the result value.
 // It is a shorthand of Policy.Start and Retrier.Continue.
-// If f returns an error, retry to execute f until f returns nil error.
-// If the error is wrapped by [MarkTemporary], DoValue doesn't retry and returns the error.
+// If f returns an error, DoValue retries until f succeeds or the retry limit is reached.
+//
+// Error handling:
+//   - [MarkPermanent]: stops retrying immediately and returns the unwrapped error
+//   - [MarkTemporary]: continues retrying (explicit marker for retryable errors)
+//   - Unmarked errors: treated as temporary and retried
 func DoValue[T any](ctx context.Context, policy *Policy, f func() (T, error)) (T, error) {
 	var zero T
 	var err error

--- a/retry.go
+++ b/retry.go
@@ -56,8 +56,12 @@ func (p *Policy) Start(ctx context.Context) *Retrier {
 
 // Do executes f with retrying policy.
 // It is a shorthand of Policy.Start and Retrier.Continue.
-// If f returns an error, retry to execute f until f returns nil error.
-// If the error is wrapped by [MarkTemporary], Do doesn't retry and returns the error.
+// If f returns an error, Do retries until f returns nil or the retry limit is reached.
+//
+// Error handling:
+//   - [MarkPermanent]: stops retrying immediately and returns the unwrapped error
+//   - [MarkTemporary]: continues retrying (explicit marker for retryable errors)
+//   - Unmarked errors: treated as temporary and retried
 func (p *Policy) Do(ctx context.Context, f func() error) error {
 	var err error
 	var target *temporary


### PR DESCRIPTION
Thank you for always maintaining this great OSS!

## Summary

- Fix incorrect documentation for `Policy.Do` and `DoValue` functions
- The docs incorrectly stated `MarkTemporary` stops retrying, but it's actually `MarkPermanent`
- Clarify error handling behavior for all three cases: MarkPermanent, MarkTemporary, and unmarked errors

## Changes

- `retry.go`: Update `Policy.Do` doc comment
- `func.go`: Update `DoValue` doc comment


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified error-handling behavior in retry logic documentation, including how permanent and temporary errors are treated during retry operations.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->